### PR TITLE
Add getter for map in System.

### DIFF
--- a/include/System.h
+++ b/include/System.h
@@ -90,6 +90,10 @@ public:
     // This function must be called before saving the trajectory.
     void Shutdown();
 
+    // Get map with tracked frames and points.
+    // Call first Shutdown()
+    Map *GetMap();
+
     // Save camera trajectory in the TUM RGB-D dataset format.
     // Call first Shutdown()
     // See format details at: http://vision.in.tum.de/data/datasets/rgbd-dataset

--- a/src/System.cc
+++ b/src/System.cc
@@ -280,6 +280,11 @@ void System::Shutdown()
     pangolin::BindToContext("ORB-SLAM2: Map Viewer");
 }
 
+Map *System::GetMap()
+{
+    return mpMap;
+}
+
 void System::SaveTrajectoryTUM(const string &filename)
 {
     cout << endl << "Saving camera trajectory to " << filename << " ..." << endl;


### PR DESCRIPTION
This allows users of the library to extract and save map
information without needing to modify the library code.
