### PR TITLE
added additional include files to get code to compile on Ubuntu 14.04.

### DIFF
--- a/Examples/Monocular/mono_kitti.cc
+++ b/Examples/Monocular/mono_kitti.cc
@@ -20,6 +20,7 @@
 
 
 #include<iostream>
+#include<iomanip>
 #include<algorithm>
 #include<fstream>
 #include<chrono>

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -20,6 +20,7 @@
 
 
 #include<iostream>
+#include<iomanip>
 #include<algorithm>
 #include<fstream>
 #include<chrono>

--- a/src/ORBextractor.cc
+++ b/src/ORBextractor.cc
@@ -56,6 +56,8 @@
 
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#include <opencv2/features2d/features2d.hpp>
 #include <vector>
 
 #include "ORBextractor.h"

--- a/src/System.cc
+++ b/src/System.cc
@@ -24,6 +24,7 @@
 #include "Converter.h"
 #include <thread>
 #include <pangolin/pangolin.h>
+#include <iomanip>
 
 namespace ORB_SLAM2
 {


### PR DESCRIPTION
I got compiler errors due to missing inclusion of header files. I'm somewhat perplexed by the fact that it would compile on your systems without inclusion of <iomanip>.

I also needed a small number of additional opencv includes (compiling against opencv 3.1).


