### PR TITLE
Avoid infinite jobs issue of make

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,19 +1,21 @@
+[ -z "$MAKEFLAGS" ] && export MAKEFLAGS="-j"
+
 echo "Configuring and building Thirdparty/DBoW2 ..."
 
 cd Thirdparty/DBoW2
-mkdir build
+mkdir -p build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j
+make
 
 cd ../../g2o
 
 echo "Configuring and building Thirdparty/g2o ..."
 
-mkdir build
+mkdir -p build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j
+make
 
 cd ../../../
 
@@ -25,7 +27,7 @@ cd ..
 
 echo "Configuring and building ORB_SLAM2 ..."
 
-mkdir build
+mkdir -p build
 cd build
 cmake .. -DCMAKE_BUILD_TYPE=Release
-make -j
+make

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-[ -z "$MAKEFLAGS" ] && export MAKEFLAGS="-j"
+[ -n "$MAKEFLAGS" ] || export MAKEFLAGS="-j"
 
 echo "Configuring and building Thirdparty/DBoW2 ..."
 


### PR DESCRIPTION
**build.sh: avoid make mistakes choosing number of jobs (-j)**
This patch is a woraround to fix computer hang due
make's error guesing number of jobs.
Also allows define a limited number of jobs to target
low memory systems.

To get old behavior you must do:
  MAKEFLAGS='-j' ./build.sh

Extra: `mkdir -p` to ensure idempotence behavior and
success exit status


> This might be just for me or my computer setup. But does not hurts.