### PR TITLE
Publish camera pose as tf ros message

### DIFF
--- a/Examples/ROS/ORB_SLAM2/src/ros_rgbd.cc
+++ b/Examples/ROS/ORB_SLAM2/src/ros_rgbd.cc
@@ -29,7 +29,6 @@
 #include <message_filters/time_synchronizer.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include "geometry_msgs/TransformStamped.h"
-#include <opencv2/core/core.hpp>
 #include "../../../include/System.h"
 #include "tf/transform_datatypes.h"
 #include <tf/transform_broadcaster.h>
@@ -68,7 +67,6 @@ int main(int argc, char **argv)
 
     message_filters::Subscriber<sensor_msgs::Image> rgb_sub(nh, "/camera/rgb/image_raw", 1);
     message_filters::Subscriber<sensor_msgs::Image> depth_sub(nh, "/camera/depth_registered/sw_registered/image_rect", 1);
-    ros::Publisher pub_vision = nh.advertise<geometry_msgs::PoseStamped>("/mavros/vision_pose/pose",100);
     typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image> sync_pol;
     message_filters::Synchronizer<sync_pol> sync(sync_pol(10), rgb_sub,depth_sub);
     sync.registerCallback(boost::bind(&ImageGrabber::GrabRGBD,&igb,_1,_2));

--- a/Examples/ROS/ORB_SLAM2/src/ros_rgbd.cc
+++ b/Examples/ROS/ORB_SLAM2/src/ros_rgbd.cc
@@ -36,7 +36,6 @@
 
 
 using namespace std;
-double PI = 3.14159265359;
 
 class ImageGrabber
 {

--- a/Examples/ROS/ORB_SLAM2/src/ros_rgbd.cc
+++ b/Examples/ROS/ORB_SLAM2/src/ros_rgbd.cc
@@ -36,8 +36,6 @@
 
 
 using namespace std;
-using namespace tf;
-//using namespace cv;
 
 class ImageGrabber
 {
@@ -69,7 +67,6 @@ int main(int argc, char **argv)
     ros::NodeHandle nh;
 
     message_filters::Subscriber<sensor_msgs::Image> rgb_sub(nh, "/camera/rgb/image_raw", 1);
-    //message_filters::Subscriber<sensor_msgs::Image> depth_sub(nh, "camera/depth_registered/image_raw", 1);
     message_filters::Subscriber<sensor_msgs::Image> depth_sub(nh, "/camera/depth_registered/sw_registered/image_rect", 1);
     typedef message_filters::sync_policies::ApproximateTime<sensor_msgs::Image, sensor_msgs::Image> sync_pol;
     message_filters::Synchronizer<sync_pol> sync(sync_pol(10), rgb_sub,depth_sub);


### PR DESCRIPTION
Ros rgbd example:
- Transforms camera pose into right handed frame 
- Transform camera frame into NED body frame (x forwards, y right, z down) 
- publishes pose as tf message
