### PR TITLE
BugFix,Update Initializer.cc

### DIFF
--- a/src/Initializer.cc
+++ b/src/Initializer.cc
@@ -175,7 +175,7 @@ void Initializer::FindHomography(vector<bool> &vbMatchesInliers, float &score, c
 void Initializer::FindFundamental(vector<bool> &vbMatchesInliers, float &score, cv::Mat &F21)
 {
     // Number of putative matches
-    const int N = vbMatchesInliers.size();
+    const int N = mvMatches12.size();
 
     // Normalize coordinates
     vector<cv::Point2f> vPn1, vPn2;


### PR DESCRIPTION
in function FindFundamental(),the putative matches=mvMatches12.size().The result of vbMatchesInliers.size() is 0.