### PR TITLE
Updated ROS Examples' CMake.txt for use with OpenCV versions > 2.4.3

### DIFF
--- a/Examples/ROS/ORB_SLAM2/CMakeLists.txt
+++ b/Examples/ROS/ORB_SLAM2/CMakeLists.txt
@@ -30,7 +30,14 @@ endif()
 
 LIST(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../../../cmake_modules)
 
-find_package(OpenCV 2.4.3 REQUIRED)
+find_package(OpenCV 2.4.3 QUIET)
+if(NOT OpenCV_FOUND)
+   find_package(OpenCV 3.0 QUIET)
+   if(NOT OpenCV_FOUND)
+      message(FATAL_ERROR "OpenCV > 2.4.3 not found.")
+   endif()
+endif()
+
 find_package(Eigen3 3.1.0 REQUIRED)
 find_package(Pangolin REQUIRED)
 


### PR DESCRIPTION
Just updated the find_package(OpenCV) code for the ROS examples to match the your top level CMake.txt file. I was able to successfully build on Ubuntu 16.04 with OpenCV 3.2 and ROS Kinetic after making this one change. Hope this is helpful!