### PR TITLE
Prevent possible infinite loop in keyframe traversal

### DIFF
--- a/include/KeyFrame.h
+++ b/include/KeyFrame.h
@@ -115,7 +115,8 @@ public:
     static bool lId(KeyFrame* pKF1, KeyFrame* pKF2){
         return pKF1->mnId<pKF2->mnId;
     }
-
+    // Flag to ensure completion of traversal
+    bool mbVisited;
 
     // The following variables are accesed from only 1 thread or never change (no mutex needed).
 public:

--- a/src/KeyFrame.cc
+++ b/src/KeyFrame.cc
@@ -29,7 +29,7 @@ namespace ORB_SLAM2
 long unsigned int KeyFrame::nNextId=0;
 
 KeyFrame::KeyFrame(Frame &F, Map *pMap, KeyFrameDatabase *pKFDB):
-    mnFrameId(F.mnId),  mTimeStamp(F.mTimeStamp), mnGridCols(FRAME_GRID_COLS), mnGridRows(FRAME_GRID_ROWS),
+    mbVisited(false), mnFrameId(F.mnId),  mTimeStamp(F.mTimeStamp), mnGridCols(FRAME_GRID_COLS), mnGridRows(FRAME_GRID_ROWS),
     mfGridElementWidthInv(F.mfGridElementWidthInv), mfGridElementHeightInv(F.mfGridElementHeightInv),
     mnTrackReferenceForFrame(0), mnFuseTargetForKF(0), mnBALocalForKF(0), mnBAFixedForKF(0),
     mnLoopQuery(0), mnLoopWords(0), mnRelocQuery(0), mnRelocWords(0), mnBAGlobalForKF(0),

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -674,16 +674,22 @@ void LoopClosing::RunGlobalBundleAdjustment(unsigned long nLoopKF)
             unique_lock<mutex> lock(mpMap->mMutexMapUpdate);
 
             // Correct keyframes starting at map first keyframe
+            vector<KeyFrame *> vpKeyFrames = mpMap->GetAllKeyFrames();
+            for (int i = 0; i < (int)vpKeyFrames.size(); i++)
+                vpKeyFrames[i]->mbVisited = false;
+
             list<KeyFrame*> lpKFtoCheck(mpMap->mvpKeyFrameOrigins.begin(),mpMap->mvpKeyFrameOrigins.end());
 
             while(!lpKFtoCheck.empty())
             {
                 KeyFrame* pKF = lpKFtoCheck.front();
+                pKF->mbVisited = true;
                 const set<KeyFrame*> sChilds = pKF->GetChilds();
                 cv::Mat Twc = pKF->GetPoseInverse();
                 for(set<KeyFrame*>::const_iterator sit=sChilds.begin();sit!=sChilds.end();sit++)
                 {
                     KeyFrame* pChild = *sit;
+                    if(pChild->mbVisited) continue;
                     if(pChild->mnBAGlobalForKF!=nLoopKF)
                     {
                         cv::Mat Tchildc = pChild->GetPose()*Twc;


### PR DESCRIPTION
Love this project!

I ran into a deadlock running ORB SLAM right after a loop closure after about 3 minutes of video. Tracking had stopped, local mapping had stopped, and the process was using about 1.2 CPUs but doing nothing visible. Attaching to the running process in gdb revealed that the tracking thread was waiting for  the mpMap->mMutexMapUpdate lock, but it couldn't acquire it because the loop closure thread never completed its spanning tree traversal. I guess that somehow a cycle must have been introduced into the map's keyframe spanning tree.

I suppose the inconsistency in the tree should really be further investigated and fixed, but here I've just added a "visited" flag to the keyframe data structure to prevent loop closing from getting stuck indefinitely. That seems like a good idea regardless.