### PR TITLE
Fixes bug to make keyframes write to text file

### DIFF
--- a/Examples/ROS/ORB_SLAM2/src/ros_mono.cc
+++ b/Examples/ROS/ORB_SLAM2/src/ros_mono.cc
@@ -74,7 +74,6 @@ int main(int argc, char **argv)
     }    
 
     // Create SLAM system. It initializes all system threads and gets ready to process frames.
-    // ORB_SLAM2::System SLAM(argv[1],argv[2],ORB_SLAM2::System::MONOCULAR,true);
     SLAM = new ORB_SLAM2::System(argv[1],argv[2],ORB_SLAM2::System::MONOCULAR,true);
 
     ImageGrabber igb(SLAM);


### PR DESCRIPTION
Ros shutdown was not handled properly in the previous version. Currently a new SIGINT handler has been defined and all clean up is done in the signal callback function.