### PR TITLE
CMake now installs the .so file and headers to common location.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ build/
 *~
 lib/
 
+CMakeFiles
+
+# VIM
+
+*.swp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ src/Initializer.cc
 src/Viewer.cc
 )
 
+
 target_link_libraries(${PROJECT_NAME}
 ${OpenCV_LIBS}
 ${EIGEN3_LIBS}
@@ -78,6 +79,11 @@ ${PROJECT_SOURCE_DIR}/Thirdparty/DBoW2/lib/libDBoW2.so
 ${PROJECT_SOURCE_DIR}/Thirdparty/g2o/lib/libg2o.so
 )
 
+install(TARGETS ${PROJECT_NAME}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+)
+
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_PREFIX}/include/${PROJECT_NAME})
 # Build examples
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_SOURCE_DIR}/Examples/RGB-D)
@@ -110,4 +116,6 @@ target_link_libraries(mono_kitti ${PROJECT_NAME})
 add_executable(mono_euroc
 Examples/Monocular/mono_euroc.cc)
 target_link_libraries(mono_euroc ${PROJECT_NAME})
+
+
 


### PR DESCRIPTION
The library file is installed to /usr/local/lib by default.

The header files are installed to /usr/local/include/ORB_SLAM2 by
default. The prefix '/usr/local/include/' can be changed as a CMake
variable.