### PR TITLE
Fix multiple assignment of features.

### DIFF
--- a/src/ORBmatcher.cc
+++ b/src/ORBmatcher.cc
@@ -759,6 +759,7 @@ int ORBmatcher::SearchForTriangulation(KeyFrame *pKF1, KeyFrame *pKF2, cv::Mat F
                 {
                     const cv::KeyPoint &kp2 = pKF2->mvKeysUn[bestIdx2];
                     vMatches12[idx1]=bestIdx2;
+                    vbMatched2[bestIdx2] = true;
                     nmatches++;
 
                     if(mbCheckOrientation)
@@ -802,6 +803,7 @@ int ORBmatcher::SearchForTriangulation(KeyFrame *pKF1, KeyFrame *pKF2, cv::Mat F
                 continue;
             for(size_t j=0, jend=rotHist[i].size(); j<jend; j++)
             {
+            	vbMatched2[vMatches12[rotHist[i][j]]] = false;
                 vMatches12[rotHist[i][j]]=-1;
                 nmatches--;
             }


### PR DESCRIPTION
- Fixed dangling pointer from MapPoint to KeyFrame
- Related to issue https://github.com/raulmur/ORB_SLAM2/issues/98

When matching features in ORBmatcher::SearchForTriangulation(), features from KeyFrame2 can be assigned to multiple features from KeyFrame1. This effects the function CreateNewMapPoints(), where multiple features from KeyFrame1 can be triangulated with a single feature from KeyFrame2. In consequence, by repeatedly calling the Keyframe::AddMapPoint() on KeyFrame2 with the same feature index, the previous link to the MapPoint in mvpMapPoints is overwritten. 

The result is a pointer from MapPoint to the KeyFrame, but no pointer from the KeyFrame to the MapPoint.  When calling the Keyframe::SetBadFlag(), the pointers from KeyFrame to the MapPoints are erased, but there might be some MapPoints in the rest of the Map holding a pointer to the KeyFrame. This might be related to issue 98. 