### PR TITLE
Update TUM1~3.yaml

### DIFF
--- a/Examples/RGB-D/TUM1.yaml
+++ b/Examples/RGB-D/TUM1.yaml
@@ -26,7 +26,7 @@ Camera.fps: 30.0
 Camera.bf: 40.0
 
 # Color order of the images (0: BGR, 1: RGB. It is ignored if images are grayscale)
-Camera.RGB: 1
+Camera.RGB: 0
 
 # Close/Far threshold. Baseline times.
 ThDepth: 40.0


### PR DESCRIPTION
I've found the rgb data in TUM dataset should be bgr format,
so the opencv  should use BGR2GRAY parameter.
And I test the fr1/desk and the fr2/pioneer360, get a little better  or less ATErmse result.
But I've to say another world about this rectification, it dosen't seem show better result on my dataset.

this is the rectified result for 
fr2/pioneer360
compared_pose_pairs 389 pairs
absolute_translational_error.rmse 0.040659 m
absolute_translational_error.mean 0.029143 m
absolute_translational_error.median 0.019372 m
absolute_translational_error.std 0.028352 m
absolute_translational_error.min 0.002446 m
absolute_translational_error.max 0.233460 m
fr1/desk
compared_pose_pairs 570 pairs
absolute_translational_error.rmse 0.015011 m
absolute_translational_error.mean 0.012594 m
absolute_translational_error.median 0.011420 m
absolute_translational_error.std 0.008168 m
absolute_translational_error.min 0.000820 m
absolute_translational_error.max 0.050509 m