### PR TITLE
Corrected typedef so that map value_type and allocator are the same

### DIFF
--- a/include/LoopClosing.h
+++ b/include/LoopClosing.h
@@ -47,7 +47,7 @@ public:
 
     typedef pair<set<KeyFrame*>,int> ConsistentGroup;    
     typedef map<KeyFrame*,g2o::Sim3,std::less<KeyFrame*>,
-        Eigen::aligned_allocator<std::pair<const KeyFrame*, g2o::Sim3> > > KeyFrameAndPose;
+        Eigen::aligned_allocator<std::pair<KeyFrame* const, g2o::Sim3> > > KeyFrameAndPose;
 
 public:
 


### PR DESCRIPTION
This correction was necessary in order to prevent static assertion errors in my environment. Compilation error in question:

```/home/zach/Projects/ORB-SLAM/ORB_SLAM2/src/LoopClosing.cc: In member function ‘void ORB_SLAM2::LoopClosing::CorrectLoop()’:
/home/zach/Projects/ORB-SLAM/ORB_SLAM2/src/LoopClosing.cc:416:20: warning: use of an operand of type ‘bool’ in ‘operator++’ is deprecated [-Wdeprecated]
         mnFullBAIdx++;
                    ^~
In file included from /usr/include/c++/8.1.0/map:61,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/Thirdparty/DBoW2/DBoW2/BowVector.h:14,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/Frame.h:27,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/MapPoint.h:25,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/KeyFrame.h:24,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/LoopClosing.h:24,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/src/LoopClosing.cc:21:
/usr/include/c++/8.1.0/bits/stl_map.h: In instantiation of ‘class std::map<ORB_SLAM2::KeyFrame*, g2o::Sim3, std::less<ORB_SLAM2::KeyFrame*>, Eigen::aligned_allocator<std::pair<const ORB_SLAM2::KeyFrame*, g2o::Sim3> > >’:
/home/zach/Projects/ORB-SLAM/ORB_SLAM2/src/LoopClosing.cc:438:21:   required from here
/usr/include/c++/8.1.0/bits/stl_map.h:122:21: error: static assertion failed: std::map must have the same value_type as its allocator
       static_assert(is_same<typename _Alloc::value_type, value_type>::value,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/8.1.0/map:61,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/Thirdparty/DBoW2/DBoW2/BowVector.h:14,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/KeyFrame.h:25,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/MapPoint.h:24,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/Map.h:24,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/include/Optimizer.h:24,
                 from /home/zach/Projects/ORB-SLAM/ORB_SLAM2/src/Optimizer.cc:21:
/usr/include/c++/8.1.0/bits/stl_map.h: In instantiation of ‘class std::map<ORB_SLAM2::KeyFrame*, g2o::Sim3, std::less<ORB_SLAM2::KeyFrame*>, Eigen::aligned_allocator<std::pair<const ORB_SLAM2::KeyFrame*, g2o::Sim3> > >’:
/home/zach/Projects/ORB-SLAM/ORB_SLAM2/src/Optimizer.cc:818:37:   required from here
/usr/include/c++/8.1.0/bits/stl_map.h:122:21: error: static assertion failed: std::map must have the same value_type as its allocator
       static_assert(is_same<typename _Alloc::value_type, value_type>::value,
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/ORB_SLAM2.dir/build.make:102: CMakeFiles/ORB_SLAM2.dir/src/LoopClosing.cc.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/ORB_SLAM2.dir/build.make:219: CMakeFiles/ORB_SLAM2.dir/src/Optimizer.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:253: CMakeFiles/ORB_SLAM2.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```

Resolving the error was a simple matter of declaring the pointer as const as opposed to the pointee. 

I have Eigen 3.2.10 and OpenCV 3.4.1 installed, every other dependency is the latest from git.