### PR TITLE
Fix a bug in DistributOctTree algorithm of ORBextractor.

### DIFF
--- a/include/ORBextractor.h
+++ b/include/ORBextractor.h
@@ -53,6 +53,10 @@ public:
 
     ~ORBextractor(){}
 
+    static bool CompareSmall(std::pair<int,ExtractorNode*> &p1, std::pair<int,ExtractorNode*> &p2){
+        return (p1.first<p2.first);
+    }
+
     // Compute the ORB features and descriptors on an image.
     // ORB are dispersed on the image using an octree.
     // Mask is ignored in the current implementation.

--- a/src/ORBextractor.cc
+++ b/src/ORBextractor.cc
@@ -681,7 +681,7 @@ vector<cv::KeyPoint> ORBextractor::DistributeOctTree(const vector<cv::KeyPoint>&
                 vector<pair<int,ExtractorNode*> > vPrevSizeAndPointerToNode = vSizeAndPointerToNode;
                 vSizeAndPointerToNode.clear();
 
-                sort(vPrevSizeAndPointerToNode.begin(),vPrevSizeAndPointerToNode.end());
+                sort(vPrevSizeAndPointerToNode.begin(),vPrevSizeAndPointerToNode.end(), ORBextractor::CompareSmall);
                 for(int j=vPrevSizeAndPointerToNode.size()-1;j>=0;j--)
                 {
                     ExtractorNode n1,n2,n3,n4;


### PR DESCRIPTION
DistributOctTree has a bug that causes track lost. This bug is difficult to reproduce, but the cause is the assumption of the use of same sort parameters in the function DistributeOctTree. Randomly, the sort parameters used in sort function can change and the system loses the track.