### PR TITLE
to solve the bug in KeyFrameDatabase.cc

### DIFF
--- a/src/KeyFrameDatabase.cc
+++ b/src/KeyFrameDatabase.cc
@@ -250,6 +250,10 @@ vector<KeyFrame*> KeyFrameDatabase::DetectRelocalizationCandidates(Frame *F)
             pKFi->mRelocScore=si;
             lScoreAndMatch.push_back(make_pair(si,pKFi));
         }
+        else
+        {
+             pKFi->mRelocScore = 0;
+        }
     }
 
     if(lScoreAndMatch.empty())


### PR DESCRIPTION
when accumulating score by covisibility, We use accScore+=pKF2->mRelocScore. see 280 lines. such a case, pKF2->mRelocScore maybe is a  garbage value. if  pKF2 not meet 'minCommonWords'  case first, so in original source code 249 lines, not compute score between F->mBowVec and pkF2->mBowVec. It's seem that pKF2->mRelocScore is not a certain value. if pKF2 also is appear in last Relocalization and compute score compared with last frame. so up to  current frame, 280 lines, pKF2->mRelocScore is last computed score value. to solve this problem. I try to set pKF2->mRelocScore = 0.