### PR TITLE
Fix: reset stuck

### DIFF
--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -709,7 +709,7 @@ void LocalMapping::RequestReset()
         mbResetRequested = true;
     }
 
-    while(1)
+    while(!isStopped())
     {
         {
             unique_lock<mutex> lock2(mMutexReset);
@@ -718,6 +718,12 @@ void LocalMapping::RequestReset()
         }
         usleep(3000);
     }
+
+	if (isStopped())
+	{
+		ResetIfRequested();
+		return;
+	}
 }
 
 void LocalMapping::ResetIfRequested()


### PR DESCRIPTION
When system is on the Localization mode,  local mapper resetting will be stuck.