### PR TITLE
Fix build error

### DIFF
--- a/Examples/Monocular/mono_euroc.cc
+++ b/Examples/Monocular/mono_euroc.cc
@@ -18,6 +18,7 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <unistd.h>
 
 #include<iostream>
 #include<algorithm>

--- a/Examples/Monocular/mono_kitti.cc
+++ b/Examples/Monocular/mono_kitti.cc
@@ -18,6 +18,7 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <unistd.h>
 
 #include<iostream>
 #include<algorithm>

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -18,6 +18,7 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <unistd.h>
 
 #include<iostream>
 #include<algorithm>

--- a/Examples/RGB-D/rgbd_tum.cc
+++ b/Examples/RGB-D/rgbd_tum.cc
@@ -17,7 +17,7 @@
 * You should have received a copy of the GNU General Public License
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
-
+#include <unistd.h>
 
 #include<iostream>
 #include<algorithm>

--- a/Examples/ROS/ORB_SLAM2/CMakeLists.txt
+++ b/Examples/ROS/ORB_SLAM2/CMakeLists.txt
@@ -55,6 +55,7 @@ ${Pangolin_LIBRARIES}
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/DBoW2/lib/libDBoW2.so
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/g2o/lib/libg2o.so
 ${PROJECT_SOURCE_DIR}/../../../lib/libORB_SLAM2.so
+-lboost_system
 )
 
 # Node for monocular camera

--- a/Examples/ROS/ORB_SLAM2/CMakeLists.txt
+++ b/Examples/ROS/ORB_SLAM2/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 
 find_package(Eigen3 3.1.0 REQUIRED)
 find_package(Pangolin REQUIRED)
+find_package(Boost COMPONENTS system REQUIRED)
 
 include_directories(
 ${PROJECT_SOURCE_DIR}
@@ -55,7 +56,7 @@ ${Pangolin_LIBRARIES}
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/DBoW2/lib/libDBoW2.so
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/g2o/lib/libg2o.so
 ${PROJECT_SOURCE_DIR}/../../../lib/libORB_SLAM2.so
--lboost_system
+${Boost_SYSTEM_LIBRARY}
 )
 
 # Node for monocular camera

--- a/Examples/Stereo/stereo_euroc.cc
+++ b/Examples/Stereo/stereo_euroc.cc
@@ -17,7 +17,7 @@
 * You should have received a copy of the GNU General Public License
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
-
+#include <unistd.h>
 
 #include<iostream>
 #include<algorithm>

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -17,7 +17,7 @@
 * You should have received a copy of the GNU General Public License
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
-
+#include <unistd.h>
 
 #include<iostream>
 #include<algorithm>

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -18,6 +18,7 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <unistd.h>
 #include "LocalMapping.h"
 #include "LoopClosing.h"
 #include "ORBmatcher.h"

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -17,6 +17,7 @@
 * You should have received a copy of the GNU General Public License
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
+#include <unistd.h>
 
 #include "LoopClosing.h"
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -18,7 +18,7 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
-
+#include <unistd.h>
 
 #include "System.h"
 #include "Converter.h"

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -18,6 +18,7 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <unistd.h>
 
 #include "Tracking.h"
 

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -18,6 +18,8 @@
 * along with ORB-SLAM2. If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <unistd.h>
+
 #include "Viewer.h"
 #include <pangolin/pangolin.h>
 


### PR DESCRIPTION
I think  we need "#include <unistd.h>" to avoid build error about usleep().
And I think we need "-lboost_system" in "Examples/ROS/ORB_SLAM2/CMakeLists.txt" to avoid link error.

This is my first pull request experience. Thank you.