### PR TITLE
FrameViewer has fixed window size, ROS mono takes image_topic as argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ Examples/Monocular/mono_tum
 Examples/RGB-D/rgbd_tum
 Examples/ROS/ORB_SLAM2/CMakeLists.txt.user
 Examples/ROS/ORB_SLAM2/Mono
+Examples/ROS/ORB_SLAM2/flir.yaml
 Examples/ROS/ORB_SLAM2/MonoAR
 Examples/ROS/ORB_SLAM2/RGBD
 Examples/ROS/ORB_SLAM2/Stereo

--- a/Examples/ROS/ORB_SLAM2/CMakeLists.txt
+++ b/Examples/ROS/ORB_SLAM2/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 
 find_package(Eigen3 3.1.0 REQUIRED)
 find_package(Pangolin REQUIRED)
+find_package(Boost COMPONENTS system filesystem REQUIRED)
 
 include_directories(
 ${PROJECT_SOURCE_DIR}
@@ -52,6 +53,8 @@ set(LIBS
 ${OpenCV_LIBS} 
 ${EIGEN3_LIBS}
 ${Pangolin_LIBRARIES}
+${Boost_SYSTEM_LIBRARY}
+${Boost_FILESYSTEM_LIBRARY}
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/DBoW2/lib/libDBoW2.so
 ${PROJECT_SOURCE_DIR}/../../../Thirdparty/g2o/lib/libg2o.so
 ${PROJECT_SOURCE_DIR}/../../../lib/libORB_SLAM2.so

--- a/Examples/ROS/ORB_SLAM2/src/ros_mono.cc
+++ b/Examples/ROS/ORB_SLAM2/src/ros_mono.cc
@@ -48,7 +48,7 @@ int main(int argc, char **argv)
     ros::init(argc, argv, "Mono");
     ros::start();
 
-    if(argc != 3)
+    if(argc != 4)
     {
         cerr << endl << "Usage: rosrun ORB_SLAM2 Mono path_to_vocabulary path_to_settings" << endl;        
         ros::shutdown();
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
     ImageGrabber igb(&SLAM);
 
     ros::NodeHandle nodeHandler;
-    ros::Subscriber sub = nodeHandler.subscribe("/camera/image_raw", 1, &ImageGrabber::GrabImage,&igb);
+    ros::Subscriber sub = nodeHandler.subscribe(argv[3], 1, &ImageGrabber::GrabImage,&igb);
 
     ros::spin();
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ This will create **libORB_SLAM2.so**  at *lib* folder and the executables **mono
 For a monocular input from topic `/camera/image_raw` run node ORB_SLAM2/Mono. You will need to provide the vocabulary file and a settings file. See the monocular examples above.
 
   ```
-  rosrun ORB_SLAM2 Mono PATH_TO_VOCABULARY PATH_TO_SETTINGS_FILE
+  rosrun ORB_SLAM2 Mono PATH_TO_VOCABULARY PATH_TO_SETTINGS_FILE NAME_OF_IMAGE_TOPIC
   ```
   
 ### Running Monocular Augmented Reality Demo

--- a/src/FrameDrawer.cc
+++ b/src/FrameDrawer.cc
@@ -121,8 +121,9 @@ cv::Mat FrameDrawer::DrawFrame()
 
     cv::Mat imWithInfo;
     DrawTextInfo(im,state, imWithInfo);
-
-    return imWithInfo;
+    cv::Mat imWithInfoResized = cv::Mat(480,640,CV_8UC3, cv::Scalar(0,0,0));
+    cv::resize(imWithInfo, imWithInfoResized, imWithInfoResized.size(), 0, 0, CV_INTER_AREA);
+    return imWithInfoResized;
 }
 
 


### PR DESCRIPTION
FrameViewer has fixed window size(640,480) irrespective of image resolution.
ROS mono takes image_topic as argument in argv[3] in rosrun
updated the same in ReadMe