### PR TITLE
added #include <unistd.h> to System.h

### DIFF
--- a/include/System.h
+++ b/include/System.h
@@ -25,6 +25,7 @@
 #include<string>
 #include<thread>
 #include<opencv2/core/core.hpp>
+#include <unistd.h>
 
 #include "Tracking.h"
 #include "FrameDrawer.h"


### PR DESCRIPTION
some users are facing problem when installing, a common solution is adding this line.