### PR TITLE
fix compilation error  in ubuntu16.04 

### DIFF
--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -22,7 +22,7 @@
 #include "LoopClosing.h"
 #include "ORBmatcher.h"
 #include "Optimizer.h"
-
+#include <unistd.h>
 #include<mutex>
 
 namespace ORB_SLAM2

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -27,7 +27,7 @@
 #include "Optimizer.h"
 
 #include "ORBmatcher.h"
-
+#include <unistd.h>
 #include<mutex>
 #include<thread>
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -22,6 +22,7 @@
 
 #include "System.h"
 #include "Converter.h"
+#include <unistd.h>
 #include <thread>
 #include <pangolin/pangolin.h>
 #include <iomanip>

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -32,7 +32,7 @@
 
 #include"Optimizer.h"
 #include"PnPsolver.h"
-
+#include <unistd.h>
 #include<iostream>
 
 #include<mutex>

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -20,7 +20,7 @@
 
 #include "Viewer.h"
 #include <pangolin/pangolin.h>
-
+#include <unistd.h>
 #include <mutex>
 
 namespace ORB_SLAM2


### PR DESCRIPTION
**Reason**: not include the headfile `#include <unistd.h>` 

**error message**
```
error: 'usleep' was not declared in this scope usleep(*);
```