### PR TITLE
Fix compile option mismatch with g2o dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,10 @@ ENDIF()
 
 MESSAGE("Build type: " ${CMAKE_BUILD_TYPE})
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -Wall  -O3 -march=native ")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall   -O3 -march=native")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -Wall   -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall   -O3")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -march=native")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -march=native")
 
 # Check C++11 or C++0x support
 include(CheckCXXCompilerFlag)


### PR DESCRIPTION
This compile option should match between ORB_SLAM2 and Thirdparty/g2o : `-march=native`.
The Eigen library uses this flag to compute the value of the macro `EIGEN_DEFAULT_ALIGN_BYTES`, which then impacts Matrix objects sizes in memory.

If ORB_SLAM2 and Thirdparty/g2o are compiled with and without the -march flag, code defined in .cpp files (in libg2o.so) and code defined in .h files (in libORB_SLAM2.so) will not have the same value of Eigen alignment and seg fault can appear.

In particular, segmentation fault appears when building g2o and ORB_SLAM2 in **Debug** and running examples.
In Debug, g2o is **not** compiled with the `-march=native` flag (`CMAKE_CXX_FLAGS_RELEASE`) while ORB_SLAM2 is, leading to alignment incompatibility, bad object addresses and seg fault. 
In Release, no incompatibility as the flag is used for both ORB_SLAM2 and g2o.

More information on the `-march=native` flag in g2o : https://github.com/RainerKuemmerle/g2o/pull/314.

Probably fixes #493, fixes #634 and maybe fixes #605.