### PR TITLE
Fix default node name

### DIFF
--- a/Examples/ROS/ORB_SLAM2/src/ros_stereo.cc
+++ b/Examples/ROS/ORB_SLAM2/src/ros_stereo.cc
@@ -50,7 +50,7 @@ public:
 
 int main(int argc, char **argv)
 {
-    ros::init(argc, argv, "RGBD");
+    ros::init(argc, argv, "stereo");
     ros::start();
 
     if(argc != 4)


### PR DESCRIPTION
Fixed default node name from "RGBD" to "stereo"