### PR TITLE
Updated code to be compatible with newer C++ standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 project(ORB_SLAM2)
-
+set(CMAKE_CXX_STANDARD 14)
 IF(NOT CMAKE_BUILD_TYPE)
   SET(CMAKE_BUILD_TYPE Release)
 ENDIF()
@@ -36,7 +36,7 @@ if(NOT OpenCV_FOUND)
    endif()
 endif()
 
-find_package(Eigen3 3.1.0 REQUIRED)
+find_package(Eigen3 3.1.0 REQUIRED NO_MODULE)
 find_package(Pangolin REQUIRED)
 
 include_directories(

--- a/Examples/Monocular/mono_euroc.cc
+++ b/Examples/Monocular/mono_euroc.cc
@@ -23,7 +23,7 @@
 #include<algorithm>
 #include<fstream>
 #include<chrono>
-
+#include <unistd.h>
 #include<opencv2/core/core.hpp>
 
 #include<System.h>

--- a/Examples/Monocular/mono_kitti.cc
+++ b/Examples/Monocular/mono_kitti.cc
@@ -24,7 +24,7 @@
 #include<fstream>
 #include<chrono>
 #include<iomanip>
-
+#include <unistd.h>
 #include<opencv2/core/core.hpp>
 
 #include"System.h"

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -23,7 +23,7 @@
 #include<algorithm>
 #include<fstream>
 #include<chrono>
-
+#include <unistd.h>
 #include<opencv2/core/core.hpp>
 
 #include<System.h>

--- a/Examples/RGB-D/rgbd_tum.cc
+++ b/Examples/RGB-D/rgbd_tum.cc
@@ -23,7 +23,7 @@
 #include<algorithm>
 #include<fstream>
 #include<chrono>
-
+#include <unistd.h>
 #include<opencv2/core/core.hpp>
 
 #include<System.h>

--- a/Examples/Stereo/stereo_euroc.cc
+++ b/Examples/Stereo/stereo_euroc.cc
@@ -24,7 +24,7 @@
 #include<fstream>
 #include<iomanip>
 #include<chrono>
-
+#include <unistd.h>
 #include<opencv2/core/core.hpp>
 
 #include<System.h>

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -24,7 +24,7 @@
 #include<fstream>
 #include<iomanip>
 #include<chrono>
-
+#include <unistd.h>
 #include<opencv2/core/core.hpp>
 
 #include<System.h>

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -22,7 +22,7 @@
 #include "LoopClosing.h"
 #include "ORBmatcher.h"
 #include "Optimizer.h"
-
+#include <unistd.h>
 #include<mutex>
 
 namespace ORB_SLAM2

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -30,7 +30,7 @@
 
 #include<mutex>
 #include<thread>
-
+#include <unistd.h>
 
 namespace ORB_SLAM2
 {

--- a/src/System.cc
+++ b/src/System.cc
@@ -25,7 +25,7 @@
 #include <thread>
 #include <pangolin/pangolin.h>
 #include <iomanip>
-
+#include <unistd.h>
 namespace ORB_SLAM2
 {
 

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -36,7 +36,7 @@
 #include<iostream>
 
 #include<mutex>
-
+#include <unistd.h>
 
 using namespace std;
 

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -22,7 +22,7 @@
 #include <pangolin/pangolin.h>
 
 #include <mutex>
-
+#include <unistd.h>
 namespace ORB_SLAM2
 {
 


### PR DESCRIPTION
Updated code to compile on GCC/G++ 11.4.0, OpenCV 3.3.1, CMake 3.22.1, Pangolin 0.8.0, Ubuntu 22.04.3 Jammy, and ROS2 Iron.

Primarily, the change is just a missing include in several of the files. There is also a small change in the primary `CMakeLists.txt` file to allow it to properly find OpenCV compiled and installed using `make`. 