### PR TITLE
Compatibility with Ubuntu 22.04.

### DIFF
--- a/Examples/Monocular/mono_euroc.cc
+++ b/Examples/Monocular/mono_euroc.cc
@@ -28,6 +28,8 @@
 
 #include<System.h>
 
+#include<unistd.h>
+
 using namespace std;
 
 void LoadImages(const string &strImagePath, const string &strPathTimes,

--- a/Examples/Monocular/mono_kitti.cc
+++ b/Examples/Monocular/mono_kitti.cc
@@ -29,6 +29,8 @@
 
 #include"System.h"
 
+#include<unistd.h>
+
 using namespace std;
 
 void LoadImages(const string &strSequence, vector<string> &vstrImageFilenames,

--- a/Examples/Monocular/mono_tum.cc
+++ b/Examples/Monocular/mono_tum.cc
@@ -28,6 +28,8 @@
 
 #include<System.h>
 
+#include<unistd.h>
+
 using namespace std;
 
 void LoadImages(const string &strFile, vector<string> &vstrImageFilenames,

--- a/Examples/RGB-D/rgbd_tum.cc
+++ b/Examples/RGB-D/rgbd_tum.cc
@@ -28,6 +28,8 @@
 
 #include<System.h>
 
+#include<unistd.h>
+
 using namespace std;
 
 void LoadImages(const string &strAssociationFilename, vector<string> &vstrImageFilenamesRGB,

--- a/Examples/Stereo/stereo_euroc.cc
+++ b/Examples/Stereo/stereo_euroc.cc
@@ -29,6 +29,8 @@
 
 #include<System.h>
 
+#include<unistd.h>
+
 using namespace std;
 
 void LoadImages(const string &strPathLeft, const string &strPathRight, const string &strPathTimes,

--- a/Examples/Stereo/stereo_kitti.cc
+++ b/Examples/Stereo/stereo_kitti.cc
@@ -29,6 +29,8 @@
 
 #include<System.h>
 
+#include<unistd.h>
+
 using namespace std;
 
 void LoadImages(const string &strPathToSequence, vector<string> &vstrImageLeft,

--- a/include/System.h
+++ b/include/System.h
@@ -36,6 +36,8 @@
 #include "ORBVocabulary.h"
 #include "Viewer.h"
 
+#include<unistd.h>
+
 namespace ORB_SLAM2
 {
 

--- a/src/LocalMapping.cc
+++ b/src/LocalMapping.cc
@@ -25,6 +25,8 @@
 
 #include<mutex>
 
+#include<unistd.h>
+
 namespace ORB_SLAM2
 {
 

--- a/src/LoopClosing.cc
+++ b/src/LoopClosing.cc
@@ -31,6 +31,8 @@
 #include<mutex>
 #include<thread>
 
+#include<unistd.h>
+
 
 namespace ORB_SLAM2
 {

--- a/src/System.cc
+++ b/src/System.cc
@@ -26,6 +26,8 @@
 #include <pangolin/pangolin.h>
 #include <iomanip>
 
+#include<unistd.h>
+
 namespace ORB_SLAM2
 {
 

--- a/src/System.cc
+++ b/src/System.cc
@@ -317,8 +317,8 @@ void System::Shutdown()
         usleep(5000);
     }
 
-    if(mpViewer)
-        pangolin::BindToContext("ORB-SLAM2: Map Viewer");
+    // if(mpViewer)
+    //     pangolin::BindToContext("ORB-SLAM2: Map Viewer");
 }
 
 void System::SaveTrajectoryTUM(const string &filename)

--- a/src/Tracking.cc
+++ b/src/Tracking.cc
@@ -37,6 +37,8 @@
 
 #include<mutex>
 
+#include<unistd.h>
+
 
 using namespace std;
 

--- a/src/Viewer.cc
+++ b/src/Viewer.cc
@@ -23,6 +23,8 @@
 
 #include <mutex>
 
+#include<unistd.h>
+
 namespace ORB_SLAM2
 {
 


### PR DESCRIPTION
After the update of Pangolin as well as Ubuntu systems, the original version cannot be downloaded and installed directly. It is a simple solution to this problem.